### PR TITLE
feat(jwtTokenProvider) : jwt token 관련 기능 추가 및 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.16'
 
     compile 'org.projectlombok:lombok:1.18.16'
+    compile('com.google.code.gson:gson:2.8.2')
 
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'io.rest-assured:rest-assured:4.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.security:spring-security-crypto:5.4.2'
-    implementation 'org.bouncycastle:bcprov-jdk1ㅎㄴ5on:1.68'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.68'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.16'
 
     compile 'org.projectlombok:lombok:1.18.16'
-    compile('com.google.code.gson:gson:2.8.2')
 
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'io.rest-assured:rest-assured:4.2.0'
@@ -38,7 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.security:spring-security-crypto:5.4.2'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.68'
+    implementation 'org.bouncycastle:bcprov-jdk1ㅎㄴ5on:1.68'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/src/main/java/org/poolc/api/auth/controller/AuthController.java
+++ b/src/main/java/org/poolc/api/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package org.poolc.api.auth.controller;
 
 import org.poolc.api.auth.dto.AuthRequest;
 import org.poolc.api.auth.dto.AuthResponse;
+import org.poolc.api.auth.exception.UnactivatedException;
 import org.poolc.api.auth.exception.UnauthenticatedException;
 import org.poolc.api.auth.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,5 +30,10 @@ public class AuthController {
     @ExceptionHandler(UnauthenticatedException.class)
     public ResponseEntity<String> unauthenticatedHandler(Exception e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+    @ExceptionHandler(UnactivatedException.class)
+    public ResponseEntity<String> unactivatedHandler(Exception e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
     }
 }

--- a/src/main/java/org/poolc/api/auth/exception/UnactivatedException.java
+++ b/src/main/java/org/poolc/api/auth/exception/UnactivatedException.java
@@ -1,0 +1,7 @@
+package org.poolc.api.auth.exception;
+
+public class UnactivatedException extends RuntimeException {
+    public UnactivatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
+++ b/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
@@ -41,7 +41,6 @@ public class JwtTokenProvider {
     public boolean validateToken(String token) {
         try {
             Claims claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
-            System.out.println(claims);
             if (claims.getExpiration().before(new Date())) {
                 return false;
             }

--- a/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
+++ b/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package org.poolc.api.auth.infra;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.poolc.api.member.domain.Member;
@@ -7,26 +9,45 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.HashMap;
 
 @Component
 public class JwtTokenProvider {
     @Value("${security.jwt.token.secret-key}")
-    private String secretKey = "adf";
+    private String secretKey;
     @Value("${security.jwt.token.expire-length}")
-    private long expireTimeInMS = 3600000;
+    private long expireTimeInMS;
 
     public String createToken(Member member) {
         Date now = new Date();
-
         return Jwts.builder()
-                .setIssuer("PoolC/PROJECT_NAME_HERE")
+                .claim("id", member.getUUID())
+                .claim("isAdmin", member.getIsAdmin().toString())
                 .setIssuedAt(now)
+                .setIssuer("Poolc/PROJECT_NAME_HERE")
                 .setExpiration(new Date(now.getTime() + expireTimeInMS))
-                .setClaims(Jwts
-                        .claims()
-                        .setSubject(member.getUUID())
-                        .setSubject(member.getIsAdmin().toString()))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
+    }
+
+    public HashMap<String, String> getUserInfo(String token) {
+        Claims body = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        HashMap<String, String> info = new HashMap<>();
+        info.put("id", body.get("id").toString());
+        info.put("isAdmin", body.get("isAdmin").toString());
+        return info;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+            System.out.println(claims);
+            if (claims.getExpiration().before(new Date())) {
+                return false;
+            }
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
+++ b/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
@@ -37,10 +37,6 @@ public class JwtTokenProvider {
         return new ParsedTokenValues(body);
     }
 
-    public void validateToken(String token) {
-        tryToGetTokenClaims(token);
-    }
-
     private Claims tryToGetTokenClaims(String token) {
         try {
             return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();

--- a/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
+++ b/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.poolc.api.auth.exception.UnauthenticatedException;
-import org.poolc.api.auth.vo.ParsedTokenValues;
 import org.poolc.api.member.domain.Member;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -31,13 +30,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-
-    public ParsedTokenValues getUserInfo(String token) {
-        Claims body = tryToGetTokenClaims(token);
-        return new ParsedTokenValues(body);
-    }
-
-    private Claims tryToGetTokenClaims(String token) {
+    public Claims getBodyFromJwtToken(String token) {
         try {
             return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
         } catch (JwtException | IllegalArgumentException e) {

--- a/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
+++ b/src/main/java/org/poolc/api/auth/infra/JwtTokenProvider.java
@@ -23,7 +23,7 @@ public class JwtTokenProvider {
         Date now = new Date();
         return Jwts.builder()
                 .claim("id", member.getUUID())
-                .claim("isAdmin", member.getIsAdmin().toString())
+                .claim("isAdmin", member.getIsAdmin())
                 .setIssuedAt(now)
                 .setIssuer("Poolc/PROJECT_NAME_HERE")
                 .setExpiration(new Date(now.getTime() + expireTimeInMS))

--- a/src/main/java/org/poolc/api/auth/service/AuthService.java
+++ b/src/main/java/org/poolc/api/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.poolc.api.auth.service;
 
+import org.poolc.api.auth.exception.UnauthenticatedException;
 import org.poolc.api.auth.infra.JwtTokenProvider;
 import org.poolc.api.member.domain.Member;
 import org.poolc.api.member.service.MemberService;
@@ -19,6 +20,9 @@ public class AuthService {
 
     public String createAccessToken(String loginID, String password) {
         Member member = memberService.getMemberIfRegistered(loginID, password);
+        if (!member.getIsActivated()) {
+            throw new UnauthenticatedException("인증되지 않은 회원입니다.");
+        }
         return jwtTokenProvider.createToken(member);
     }
 }

--- a/src/main/java/org/poolc/api/auth/service/AuthService.java
+++ b/src/main/java/org/poolc/api/auth/service/AuthService.java
@@ -1,6 +1,6 @@
 package org.poolc.api.auth.service;
 
-import org.poolc.api.auth.exception.UnauthenticatedException;
+import org.poolc.api.auth.exception.UnactivatedException;
 import org.poolc.api.auth.infra.JwtTokenProvider;
 import org.poolc.api.member.domain.Member;
 import org.poolc.api.member.service.MemberService;
@@ -21,7 +21,7 @@ public class AuthService {
     public String createAccessToken(String loginID, String password) {
         Member member = memberService.getMemberIfRegistered(loginID, password);
         if (!member.getIsActivated()) {
-            throw new UnauthenticatedException("인증되지 않은 회원입니다.");
+            throw new UnactivatedException("No activated user");
         }
         return jwtTokenProvider.createToken(member);
     }

--- a/src/main/java/org/poolc/api/auth/vo/ParsedTokenValues.java
+++ b/src/main/java/org/poolc/api/auth/vo/ParsedTokenValues.java
@@ -1,0 +1,15 @@
+package org.poolc.api.auth.vo;
+
+import io.jsonwebtoken.Claims;
+import lombok.Getter;
+
+@Getter
+public class ParsedTokenValues {
+    private final String isAdmin;
+    private final String UUID;
+
+    public ParsedTokenValues(Claims claims) {
+        this.isAdmin = claims.get("isAdmin").toString();
+        this.UUID = claims.get("id").toString();
+    }
+}

--- a/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
+++ b/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
@@ -74,7 +74,7 @@ public class MemberDataLoader implements CommandLineRunner {
                         null));
         memberRepository.save(
                 new Member(UUID.randomUUID().toString(),
-                        "DELETED_MEMBER_ID",
+                        "WILL_DELETE_MEMBER_ID",
                         passwordHashProvider.encodePassword("DELETED_MEMBER_PASSWORD"),
                         "example4@email.com",
                         "examplePhoneNumber4",

--- a/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
+++ b/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
@@ -72,5 +72,40 @@ public class MemberDataLoader implements CommandLineRunner {
                         null,
                         false,
                         null));
+        memberRepository.save(
+                new Member(UUID.randomUUID().toString(),
+                        "DELETED_MEMBER_ID",
+                        passwordHashProvider.encodePassword("DELETED_MEMBER_PASSWORD"),
+                        "example4@email.com",
+                        "examplePhoneNumber4",
+                        "MEMBER_NAME4",
+                        "exampleDepartment",
+                        "exampleStudentID4",
+                        true,
+                        true,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null));
+        memberRepository.save(
+                new Member(UUID.randomUUID().toString(),
+                        "UPDATE_MEMBER_ID",
+                        passwordHashProvider.encodePassword("UPDATE_MEMBER_PASSWORD"),
+                        "example5@email.com",
+                        "examplePhoneNumber5",
+                        "MEMBER_NAME5",
+                        "exampleDepartment",
+                        "exampleStudentID5",
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null));
     }
+
 }

--- a/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
+++ b/src/main/java/org/poolc/api/member/configurations/MemberDataLoader.java
@@ -1,0 +1,76 @@
+package org.poolc.api.member.configurations;
+
+
+import lombok.RequiredArgsConstructor;
+import org.poolc.api.member.domain.Member;
+import org.poolc.api.member.infra.PasswordHashProvider;
+import org.poolc.api.member.repository.MemberRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Profile("test")
+@RequiredArgsConstructor
+public class MemberDataLoader implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+    private final PasswordHashProvider passwordHashProvider;
+
+    @Override
+    public void run(String... args) {
+        memberRepository.save(
+                new Member(UUID.randomUUID().toString(),
+                        "MEMBER_ID",
+                        passwordHashProvider.encodePassword("MEMBER_PASSWORD"),
+                        "example@email.com",
+                        "examplePhoneNumber",
+                        "MEMBER_NAME",
+                        "exampleDepartment",
+                        "exampleStudentID",
+                        true,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null));
+        memberRepository.save(
+                new Member(UUID.randomUUID().toString(),
+                        "UNACCEPTED_MEMBER_ID",
+                        passwordHashProvider.encodePassword("UNACCEPTED_MEMBER_PASSWORD"),
+                        "example2@email.com",
+                        "examplePhoneNumber2",
+                        "MEMBER_NAME2",
+                        "exampleDepartment",
+                        "exampleStudentID2",
+                        false,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null));
+        memberRepository.save(
+                new Member(UUID.randomUUID().toString(),
+                        "ADMIN_ID",
+                        passwordHashProvider.encodePassword("ADMIN_PASSWORD"),
+                        "example3@email.com",
+                        "examplePhoneNumber3",
+                        "MEMBER_NAME3",
+                        "exampleDepartment",
+                        "exampleStudentID3",
+                        true,
+                        true,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null));
+    }
+}

--- a/src/main/java/org/poolc/api/member/controller/MemberController.java
+++ b/src/main/java/org/poolc/api/member/controller/MemberController.java
@@ -59,6 +59,13 @@ public class MemberController {
                 .body(new MemberResponse(member));
     }
 
+    @PutMapping(path = "/me")
+    public ResponseEntity updateMember(HttpServletRequest request, @RequestBody UpdateMemberRequest updateMemberRequest) {
+        checkIsValidMemberUpdateInput(updateMemberRequest);
+        memberService.updateMember(request.getAttribute("UUID").toString(), updateMemberRequest);
+        return ResponseEntity.ok().build();
+    }
+    
     @DeleteMapping(value = "/{loginID}")
     public ResponseEntity deleteMember(HttpServletRequest request, @PathVariable("loginID") String loginID) {
         checkAdmin(request);
@@ -68,11 +75,20 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping(path = "/me")
-    public ResponseEntity updateMember(HttpServletRequest request, @RequestBody UpdateMemberRequest updateMemberRequest) {
-        checkIsValidMemberUpdateInput(updateMemberRequest);
-        memberService.updateMember(request.getAttribute("UUID").toString(), updateMemberRequest);
-        return ResponseEntity.ok().build();
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> illegalArgumentHandler(Exception e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    }
+
+    @ExceptionHandler(UnauthenticatedException.class)
+    public ResponseEntity<String> unauthenticatedHandler(Exception e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> noSuchElementHandler(Exception e) {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
     }
 
     private void checkAdmin(HttpServletRequest request) {
@@ -112,18 +128,4 @@ public class MemberController {
         return email.matches("^[_a-z0A-Z-9-]+(.[_a-zA-Z0-9-]+)*@(?:\\w+\\.)+\\w+$");
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> illegalArgumentHandler(Exception e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
-    }
-
-    @ExceptionHandler(UnauthenticatedException.class)
-    public ResponseEntity<String> unauthenticatedHandler(Exception e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
-    }
-
-    @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<String> noSuchElementHandler(Exception e) {
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
-    }
 }

--- a/src/main/java/org/poolc/api/member/controller/MemberController.java
+++ b/src/main/java/org/poolc/api/member/controller/MemberController.java
@@ -77,7 +77,7 @@ public class MemberController {
 
     @ExceptionHandler(UnauthenticatedException.class)
     public ResponseEntity<String> unauthenticatedHandler(Exception e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
     }
 
     @ExceptionHandler({NoSuchElementException.class, IllegalArgumentException.class})

--- a/src/main/java/org/poolc/api/member/controller/MemberController.java
+++ b/src/main/java/org/poolc/api/member/controller/MemberController.java
@@ -1,13 +1,22 @@
 package org.poolc.api.member.controller;
 
+import org.poolc.api.auth.exception.UnauthenticatedException;
+import org.poolc.api.member.domain.Member;
 import org.poolc.api.member.dto.MemberResponse;
 import org.poolc.api.member.dto.RegisterMemberRequest;
 import org.poolc.api.member.service.MemberService;
 import org.poolc.api.member.vo.MemberCreateValues;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/member")
@@ -29,8 +38,58 @@ public class MemberController {
     }
 
     @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<MemberResponse> getMember() {
-        return ResponseEntity.badRequest().build();
+    public ResponseEntity<MemberResponse> getMember(HttpServletRequest request) {
+        Member member = memberService.getMemberByUUIDIfRegistered(request.getAttribute("UUID").toString());
+        if (!member.getIsActivated()) {
+            throw new UnauthenticatedException("아직 허가되지 않은 회원입니다");
+        }
+        return ResponseEntity.ok()
+                .body(new MemberResponse(member.getUUID(),
+                        member.getEmail(),
+                        member.getPhoneNumber(),
+                        member.getName(),
+                        member.getDepartment(),
+                        member.getStudentID(),
+                        member.getProfileImageURL(),
+                        member.getIntroduction()));
+    }
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<MemberResponse>> getAllMembers(HttpServletRequest request) {
+        Member member = memberService.getMemberByUUIDIfRegistered(request.getAttribute("UUID").toString());
+        if (request.getAttribute("isAdmin").equals("false")) {
+            throw new UnauthenticatedException("임원진이 아닙니다");
+        }
+        if (!member.getIsActivated()) {
+            throw new UnauthenticatedException("아직 허가되지 않은 회원입니다");
+        }
+
+        List<MemberResponse> memberResponses = memberService.getAllMembers()
+                .stream().map(m -> new MemberResponse(member.getUUID(),
+                        member.getEmail(),
+                        member.getPhoneNumber(),
+                        member.getName(),
+                        member.getDepartment(),
+                        member.getStudentID(),
+                        member.getProfileImageURL(),
+                        member.getIntroduction()))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok().body(memberResponses);
+    }
+
+    @DeleteMapping
+    public ResponseEntity deleteMember(HttpServletRequest request, @Param("UUID") String UUID) {
+        if (request.getAttribute("isAdmin").equals("false")) {
+            throw new UnauthenticatedException("임원진이 아닙니다");
+        }
+        memberService.deleteMemberByUUID(UUID);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping(path = "/me")
+    public ResponseEntity updateMember(HttpServletRequest request, @RequestBody RegisterMemberRequest registerMemberRequest) {
+        return ResponseEntity.ok().build();
     }
 
     private void checkIsValidMemberInput(RegisterMemberRequest request) {
@@ -47,5 +106,15 @@ public class MemberController {
 
     private boolean correctEmailFormat(RegisterMemberRequest request) {
         return request.getEmail().matches("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
+    }
+
+    @ExceptionHandler(UnauthenticatedException.class)
+    public ResponseEntity<String> unauthenticatedHandler(Exception e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> noSuchElementHandler(Exception e) {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
     }
 }

--- a/src/main/java/org/poolc/api/member/controller/MemberController.java
+++ b/src/main/java/org/poolc/api/member/controller/MemberController.java
@@ -65,7 +65,7 @@ public class MemberController {
         memberService.updateMember(request.getAttribute("UUID").toString(), updateMemberRequest);
         return ResponseEntity.ok().build();
     }
-    
+
     @DeleteMapping(value = "/{loginID}")
     public ResponseEntity deleteMember(HttpServletRequest request, @PathVariable("loginID") String loginID) {
         checkAdmin(request);
@@ -75,20 +75,14 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> illegalArgumentHandler(Exception e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
-    }
-
     @ExceptionHandler(UnauthenticatedException.class)
     public ResponseEntity<String> unauthenticatedHandler(Exception e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
     }
 
-    @ExceptionHandler(NoSuchElementException.class)
+    @ExceptionHandler({NoSuchElementException.class, IllegalArgumentException.class})
     public ResponseEntity<String> noSuchElementHandler(Exception e) {
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
     private void checkAdmin(HttpServletRequest request) {

--- a/src/main/java/org/poolc/api/member/controller/MemberController.java
+++ b/src/main/java/org/poolc/api/member/controller/MemberController.java
@@ -114,7 +114,7 @@ public class MemberController {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> illegalArgumentHandler(Exception e) {
-        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
     }
 
     @ExceptionHandler(UnauthenticatedException.class)

--- a/src/main/java/org/poolc/api/member/domain/Member.java
+++ b/src/main/java/org/poolc/api/member/domain/Member.java
@@ -3,6 +3,7 @@ package org.poolc.api.member.domain;
 import lombok.Getter;
 import org.poolc.api.common.domain.TimestampEntity;
 import org.poolc.api.domain.ProjectMember;
+import org.poolc.api.member.dto.UpdateMemberRequest;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -83,5 +84,12 @@ public class Member extends TimestampEntity {
         this.introduction = introduction;
         this.isExcepted = isExcepted;
         this.projects = projects;
+    }
+
+    public void update(UpdateMemberRequest updateMemberRequest, String passwordHash) {
+        this.name = updateMemberRequest.getName();
+        this.passwordHash = passwordHash;
+        this.email = updateMemberRequest.getEmail();
+        this.phoneNumber = updateMemberRequest.getPhoneNumber();
     }
 }

--- a/src/main/java/org/poolc/api/member/dto/MemberResponse.java
+++ b/src/main/java/org/poolc/api/member/dto/MemberResponse.java
@@ -2,10 +2,11 @@ package org.poolc.api.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
+import org.poolc.api.member.domain.Member;
 
 @Getter
 public class MemberResponse {
-    private final String uuid;
+    private final String loginID;
     private final String email;
     private final String phoneNumber;
     private final String name;
@@ -14,15 +15,16 @@ public class MemberResponse {
     private final String profileImageURL;
     private final String introduction;
 
+
     @JsonCreator
-    public MemberResponse(String UUID, String email, String phoneNumber, String name, String department, String studentID, String profileImageURL, String introduction) {
-        this.uuid = UUID;
-        this.email = email;
-        this.phoneNumber = phoneNumber;
-        this.name = name;
-        this.department = department;
-        this.studentID = studentID;
-        this.profileImageURL = profileImageURL;
-        this.introduction = introduction;
+    public MemberResponse(Member member) {
+        this.loginID = member.getLoginID();
+        this.email = member.getEmail();
+        this.phoneNumber = member.getPhoneNumber();
+        this.name = member.getName();
+        this.department = member.getDepartment();
+        this.studentID = member.getStudentID();
+        this.profileImageURL = member.getProfileImageURL();
+        this.introduction = member.getIntroduction();
     }
 }

--- a/src/main/java/org/poolc/api/member/dto/MemberResponse.java
+++ b/src/main/java/org/poolc/api/member/dto/MemberResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Getter
 public class MemberResponse {
+    private final String uuid;
     private final String email;
     private final String phoneNumber;
     private final String name;
@@ -14,7 +15,8 @@ public class MemberResponse {
     private final String introduction;
 
     @JsonCreator
-    public MemberResponse(String email, String phoneNumber, String name, String department, String studentID, String profileImageURL, String introduction) {
+    public MemberResponse(String UUID, String email, String phoneNumber, String name, String department, String studentID, String profileImageURL, String introduction) {
+        this.uuid = UUID;
         this.email = email;
         this.phoneNumber = phoneNumber;
         this.name = name;

--- a/src/main/java/org/poolc/api/member/dto/UpdateMemberRequest.java
+++ b/src/main/java/org/poolc/api/member/dto/UpdateMemberRequest.java
@@ -1,0 +1,22 @@
+package org.poolc.api.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+@Getter
+public class UpdateMemberRequest {
+    private final String name;
+    private final String password;
+    private final String passwordCheck;
+    private final String email;
+    private final String phoneNumber;
+
+    @JsonCreator
+    public UpdateMemberRequest(String name, String password, String passwordCheck, String email, String phoneNumber) {
+        this.name = name;
+        this.password = password;
+        this.passwordCheck = passwordCheck;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
+++ b/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
@@ -45,9 +45,6 @@ public class BearerAuthInterceptor implements HandlerInterceptor {
         if (token.contains("Bearer"))
             return token.replace("Bearer ", "");
 
-        if (token.contains("Basic"))
-            return token.replace("Basic ", "");
-
         return token;
     }
 }

--- a/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
+++ b/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
@@ -1,0 +1,36 @@
+package org.poolc.api.member.infra;
+
+import org.poolc.api.auth.infra.JwtTokenProvider;
+import org.poolc.api.auth.vo.ParsedTokenValues;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class BearerAuthInterceptor implements HandlerInterceptor {
+    private JwtTokenProvider jwtTokenProvider;
+
+    public BearerAuthInterceptor(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response, Object handler) {
+        if (request.getMethod().equals("POST")) {
+            return true;
+        }
+        String token = removeBearerFromToken(request.getHeader("authorization"));
+        jwtTokenProvider.validateToken(token);
+        ParsedTokenValues userInfo = jwtTokenProvider.getUserInfo(token);
+        request.setAttribute("UUID", userInfo.getUUID());
+        request.setAttribute("isAdmin", userInfo.getIsAdmin());
+        return true;
+    }
+
+    String removeBearerFromToken(String token) {
+        return token.substring(7);
+    }
+}

--- a/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
+++ b/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
@@ -1,5 +1,6 @@
 package org.poolc.api.member.infra;
 
+import io.jsonwebtoken.Claims;
 import org.poolc.api.auth.infra.JwtTokenProvider;
 import org.poolc.api.auth.vo.ParsedTokenValues;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,14 +22,23 @@ public class BearerAuthInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request,
                              HttpServletResponse response, Object handler) {
-        if (request.getMethod().equals("POST")) {
+        if (request.getMethod().equals("POST") && request.getRequestURI().equals("/member")) {
             return true;
         }
-        String token = parsingJwtToken(request.getHeader("authorization"));
-        ParsedTokenValues userInfo = jwtTokenProvider.getUserInfo(token);
+
+        ParsedTokenValues userInfo = getUserInfo(request);
+
         request.setAttribute("UUID", userInfo.getUUID());
         request.setAttribute("isAdmin", userInfo.getIsAdmin());
+
         return true;
+    }
+
+    private ParsedTokenValues getUserInfo(HttpServletRequest request) {
+        String token = parsingJwtToken(request.getHeader("authorization"));
+        Claims body = jwtTokenProvider.getBodyFromJwtToken(token);
+        ParsedTokenValues userInfo = new ParsedTokenValues(body);
+        return userInfo;
     }
 
     private String parsingJwtToken(String token) {

--- a/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
+++ b/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
@@ -23,7 +23,6 @@ public class BearerAuthInterceptor implements HandlerInterceptor {
             return true;
         }
         String token = removeBearerFromToken(request.getHeader("authorization"));
-        jwtTokenProvider.validateToken(token);
         ParsedTokenValues userInfo = jwtTokenProvider.getUserInfo(token);
         request.setAttribute("UUID", userInfo.getUUID());
         request.setAttribute("isAdmin", userInfo.getIsAdmin());

--- a/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
+++ b/src/main/java/org/poolc/api/member/infra/BearerAuthInterceptor.java
@@ -2,6 +2,7 @@ package org.poolc.api.member.infra;
 
 import org.poolc.api.auth.infra.JwtTokenProvider;
 import org.poolc.api.auth.vo.ParsedTokenValues;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -12,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 public class BearerAuthInterceptor implements HandlerInterceptor {
     private JwtTokenProvider jwtTokenProvider;
 
+    @Autowired
     public BearerAuthInterceptor(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
@@ -22,14 +24,20 @@ public class BearerAuthInterceptor implements HandlerInterceptor {
         if (request.getMethod().equals("POST")) {
             return true;
         }
-        String token = removeBearerFromToken(request.getHeader("authorization"));
+        String token = parsingJwtToken(request.getHeader("authorization"));
         ParsedTokenValues userInfo = jwtTokenProvider.getUserInfo(token);
         request.setAttribute("UUID", userInfo.getUUID());
         request.setAttribute("isAdmin", userInfo.getIsAdmin());
         return true;
     }
 
-    String removeBearerFromToken(String token) {
-        return token.substring(7);
+    private String parsingJwtToken(String token) {
+        if (token.contains("Bearer"))
+            return token.replace("Bearer ", "");
+
+        if (token.contains("Basic"))
+            return token.replace("Basic ", "");
+
+        return token;
     }
 }

--- a/src/main/java/org/poolc/api/member/infra/WebMvcConfig.java
+++ b/src/main/java/org/poolc/api/member/infra/WebMvcConfig.java
@@ -14,6 +14,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/member");
-        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/member/me");
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/member/**");
     }
 }

--- a/src/main/java/org/poolc/api/member/infra/WebMvcConfig.java
+++ b/src/main/java/org/poolc/api/member/infra/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package org.poolc.api.member.infra;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final BearerAuthInterceptor bearerAuthInterceptor;
+
+    public WebMvcConfig(BearerAuthInterceptor bearerAuthInterceptor) {
+        this.bearerAuthInterceptor = bearerAuthInterceptor;
+    }
+
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/member");
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/member/me");
+    }
+}

--- a/src/main/java/org/poolc/api/member/repository/MemberRepository.java
+++ b/src/main/java/org/poolc/api/member/repository/MemberRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, String> {
 
     Member findByLoginID(String loginID);
-
+    
     boolean existsByLoginIDOrEmailOrPhoneNumberOrStudentID(String loginID, String email, String phoneNumber, String studentID);
 }

--- a/src/main/java/org/poolc/api/member/repository/MemberRepository.java
+++ b/src/main/java/org/poolc/api/member/repository/MemberRepository.java
@@ -3,9 +3,11 @@ package org.poolc.api.member.repository;
 import org.poolc.api.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, String> {
 
-    Member findByLoginID(String loginID);
-    
+    Optional<Member> findByLoginID(String loginID);
+
     boolean existsByLoginIDOrEmailOrPhoneNumberOrStudentID(String loginID, String email, String phoneNumber, String studentID);
 }

--- a/src/main/java/org/poolc/api/member/service/MemberService.java
+++ b/src/main/java/org/poolc/api/member/service/MemberService.java
@@ -76,13 +76,8 @@ public class MemberService {
 
     public Member getMemberIfRegistered(String loginID, String password) {
         return Optional.ofNullable(memberRepository.findByLoginID(loginID))
-                .filter(member -> {
-                    if (!member.isEmpty()) {
-                        return passwordHashProvider.matches(password, member.get().getPasswordHash());
-                    }
-                    return false;
-                })
-                .orElseThrow(() -> new UnauthenticatedException("No user found with given loginID and password"))
-                .get();
+                .get()
+                .filter(member -> passwordHashProvider.matches(password, member.getPasswordHash()))
+                .orElseThrow(() -> new UnauthenticatedException("No user found with given loginID and password"));
     }
 }

--- a/src/main/java/org/poolc/api/member/service/MemberService.java
+++ b/src/main/java/org/poolc/api/member/service/MemberService.java
@@ -76,8 +76,13 @@ public class MemberService {
 
     public Member getMemberIfRegistered(String loginID, String password) {
         return Optional.ofNullable(memberRepository.findByLoginID(loginID))
-                .filter(member -> passwordHashProvider.matches(password, member.get().getPasswordHash()))
-                .get()
-                .orElseThrow(() -> new UnauthenticatedException("No user found with given loginID and password"));
+                .filter(member -> {
+                    if (!member.isEmpty()) {
+                        return passwordHashProvider.matches(password, member.get().getPasswordHash());
+                    }
+                    return false;
+                })
+                .orElseThrow(() -> new UnauthenticatedException("No user found with given loginID and password"))
+                .get();
     }
 }

--- a/src/main/java/org/poolc/api/member/service/MemberService.java
+++ b/src/main/java/org/poolc/api/member/service/MemberService.java
@@ -9,6 +9,8 @@ import org.poolc.api.member.vo.MemberCreateValues;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,6 +50,20 @@ public class MemberService {
                         null,
                         false,
                         null));
+    }
+
+    public void deleteMemberByUUID(String UUID) {
+        memberRepository.delete(memberRepository.findById(UUID)
+                .orElseThrow(() -> new NoSuchElementException("No user found with given UUID")));
+    }
+
+    public Member getMemberByUUIDIfRegistered(String UUID) {
+        return memberRepository.findById(UUID)
+                .orElseThrow(() -> new NoSuchElementException("No user found with given UUID"));
+    }
+
+    public List<Member> getAllMembers() {
+        return memberRepository.findAll();
     }
 
     public Member getMemberIfRegistered(String loginID, String password) {

--- a/src/test/java/org/poolc/api/auth/AuthAcceptanceTest.java
+++ b/src/test/java/org/poolc/api/auth/AuthAcceptanceTest.java
@@ -25,6 +25,13 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void loginWrongPassword() {
+        ExtractableResponse<Response> response = loginRequest("MEMBER_ID", "MEMBER_PASSWOR");
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
     void unauthorizedUser() {
         String loginID = "non_existing_loginID";
         String password = "non_existing_password";

--- a/src/test/java/org/poolc/api/auth/AuthAcceptanceTest.java
+++ b/src/test/java/org/poolc/api/auth/AuthAcceptanceTest.java
@@ -9,18 +9,15 @@ import org.poolc.api.auth.dto.AuthRequest;
 import org.poolc.api.auth.dto.AuthResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.poolc.api.member.MemberAcceptanceTest.createMemberRequest;
 
+@ActiveProfiles("test")
 public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     void tokenIsIssued() {
-        String loginID = "new_test_id";
-        String password = "test";
-
-        createMemberRequest("someName", loginID, password, password, "some@email.com", "010-4321-4321", "풀씨학부", "2021147599");
-        ExtractableResponse<Response> response = loginRequest(loginID, password);
+        ExtractableResponse<Response> response = loginRequest("MEMBER_ID", "MEMBER_PASSWORD");
 
         AuthResponse authResponse = response.as(AuthResponse.class);
         assertThat(response.statusCode()).isEqualTo(200);
@@ -36,6 +33,17 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
+
+    @Test
+    void unactivatedUser() {
+        String loginID = "UNACCEPTED_MEMBER_ID";
+        String password = "UNACCEPTED_MEMBER_PASSWORD";
+
+        ExtractableResponse<Response> response = loginRequest(loginID, password);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
 
     public static ExtractableResponse<Response> loginRequest(String loginID, String password) {
         AuthRequest request = new AuthRequest(loginID, password);

--- a/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
+++ b/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
@@ -1,7 +1,5 @@
 package org.poolc.api.member;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -15,8 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,7 +79,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = updateMemberInfoRequest(accessToken, "NEW_MEMBER_NAME", "UPDATE_MEMBER_PASSWORD", "NEW_PASSWORD", "NEW@naver.com", "01033334444");
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
 
     }
 
@@ -109,10 +105,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .getAccessToken();
 
         ExtractableResponse<Response> memberResponse = getMembersRequest(accessToken);
-        Gson gson = new Gson();
-        Type type = new TypeToken<ArrayList<MemberResponse>>() {
-        }.getType();
-        List<MemberResponse> list = gson.fromJson(memberResponse.body().asString(), type);
+
         ExtractableResponse<Response> response = deleteMemberRequest(accessToken, "DELETED_MEMBER_ID");
 
 

--- a/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
+++ b/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
@@ -34,7 +34,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
     void testGetMe() {
-        // TODO: loginID와 password 계속 중복되고 있는데, CMD + R 로 한번에 바꿔보아요
         String accessToken = loginRequest("MEMBER_ID", "MEMBER_PASSWORD")
                 .as(AuthResponse.class)
                 .getAccessToken();
@@ -48,7 +47,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
     void getAllMembersAsAdmin() {
-        // 임원진이 요청 보낸다고 가정
         String accessToken = loginRequest("ADMIN_ID", "ADMIN_PASSWORD")
                 .as(AuthResponse.class)
                 .getAccessToken();
@@ -56,7 +54,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = getMembersRequest(accessToken);
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.body().as(List.class)).hasSize(5); // TODO: 만든 회원 수에 맞게 변경
+        assertThat(response.body().as(List.class)).hasSize(5);
     }
 
     @Test
@@ -67,7 +65,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = getMembersRequest(accessToken);
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
     }
 
     @Test
@@ -125,9 +123,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .as(AuthResponse.class)
                 .getAccessToken();
 
-        ExtractableResponse<Response> response = deleteMemberRequest(accessToken, "NO_MEMBER_ID");
+        ExtractableResponse<Response> response = deleteMemberRequest(accessToken, "WILL_DELETE_MEMBER_ID");
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
     }
 
     public static ExtractableResponse<Response> createMemberRequest(String name, String loginID, String password, String passwordCheck, String email, String phone, String department, String studentID) {

--- a/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
+++ b/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
@@ -35,7 +35,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void testGetMe() {
         // TODO: loginID와 password 계속 중복되고 있는데, CMD + R 로 한번에 바꿔보아요
-        // Dataloader에 인증된 회원이 있다고 가정
         String accessToken = loginRequest("MEMBER_ID", "MEMBER_PASSWORD")
                 .as(AuthResponse.class)
                 .getAccessToken();
@@ -104,10 +103,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .as(AuthResponse.class)
                 .getAccessToken();
 
-        ExtractableResponse<Response> memberResponse = getMembersRequest(accessToken);
-
-        ExtractableResponse<Response> response = deleteMemberRequest(accessToken, "DELETED_MEMBER_ID");
-
+        ExtractableResponse<Response> response = deleteMemberRequest(accessToken, "WILL_DELETE_MEMBER_ID");
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }

--- a/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
+++ b/src/test/java/org/poolc/api/member/MemberAcceptanceTest.java
@@ -79,7 +79,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = updateMemberInfoRequest(accessToken, "NEW_MEMBER_NAME", "UPDATE_MEMBER_PASSWORD", "NEW_PASSWORD", "NEW@naver.com", "01033334444");
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
 
     }
 
@@ -120,7 +120,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = deleteMemberRequest(accessToken, "NO_MEMBER_ID");
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
     @Test


### PR DESCRIPTION
### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] validateToken method 추가
- [x] getUserInfo method 추가
- [x] 디버깅용으로 넣어둔 secretkey, expireTimeInMS 값 삭제
- [x] createToken method 수정


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- jwt 토큰을 decode 하여 올바른 토큰인지, 기간이 만료되지 않은 토큰인지 확인하는 validateToken를 추가하였습니다
- 현재 저희가 token 안의 두가지의 정보를 담는데 그 두가지의 정보를 hashmap으로 반환하는 userInfo Method를 추가하였습니다.
- 기존에 있던 createToken method에서 setClaim를 하면 앞에 있던 기존 정보들이 지워집니다. (issuer,issuedAt,expirationTime). 따라서 setClaim 대신 claim을 사용하여 여러가지 정보들이 claim 안에 담기도록 변경하였습니다.

<br/><br/>
